### PR TITLE
Add missing `<cstddef>` include

### DIFF
--- a/kvm_test.cpp
+++ b/kvm_test.cpp
@@ -3,6 +3,7 @@
 #include <linux/kvm.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <cstddef>
 #include <cstring>
 #include <sys/mman.h>
 #include <stdarg.h>


### PR DESCRIPTION
Fixes build failing on 64-bit raspbian with g++ due to `offsetof` not being defined